### PR TITLE
feat: Input 컴포넌트 비제어 컴포넌트로도 사용할 수 있도록 수정

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React, { FocusEvent, InputHTMLAttributes, useCallback, useState } from 'react';
+import React, { ChangeEvent, FocusEvent, forwardRef, InputHTMLAttributes, useCallback, useState } from 'react';
 import '../../assets/styles/reset.css';
 import { token } from '../../common/token';
 import { Theme } from '../../common/type';
@@ -11,11 +11,6 @@ interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, 'style' | 'c
    * 테마
    */
   theme: Theme;
-
-  /**
-   * 입력한 값
-   */
-  value: string;
 
   /**
    * onChangeless // TODO: 이름이 명확하지 않음
@@ -42,63 +37,69 @@ interface Props extends Omit<InputHTMLAttributes<HTMLInputElement>, 'style' | 'c
  *
  * @author hyeonkim
  */
-export function Input({
-  theme,
-  value,
-  placeholder,
-  hasError,
-  errorMessage,
-  onFocus,
-  onBlur,
-  onChangeless,
-  ...rest
-}: Props) {
-  const [isFocus, setIsFocus] = useState(false);
+export const Input = forwardRef<HTMLInputElement, Props>(
+  (
+    { theme, placeholder, hasError, errorMessage, onFocus, onBlur, onChange, value, onChangeless, children, ...rest },
+    ref,
+  ) => {
+    const [isFocus, setIsFocus] = useState(false);
+    const [input, setInput] = useState(value || '');
 
-  const handleFocus = useCallback(
-    (event: FocusEvent<HTMLInputElement>) => {
-      setIsFocus(true);
-      if (onFocus) {
-        onFocus(event);
-      }
-    },
-    [onFocus],
-  );
+    const handleFocus = useCallback(
+      (event: FocusEvent<HTMLInputElement>) => {
+        setIsFocus(true);
+        if (onFocus) {
+          onFocus(event);
+        }
+      },
+      [onFocus],
+    );
 
-  const handleBlur = useCallback(
-    (event: FocusEvent<HTMLInputElement>) => {
-      setIsFocus(false);
-      if (onBlur) {
-        onBlur(event);
-      }
-    },
-    [onBlur],
-  );
+    const handleBlur = useCallback(
+      (event: FocusEvent<HTMLInputElement>) => {
+        setIsFocus(false);
+        if (onBlur) {
+          onBlur(event);
+        }
+      },
+      [onBlur],
+    );
 
-  return (
-    <div>
-      <div className={containerStyle(theme, hasError)}>
-        <span className={placeholderStyle(theme, isFocus, value.length > 0, hasError, onChangeless)}>
-          {placeholder}
-        </span>
-        <div className={inputWrapperStyle(onChangeless)}>
-          <input
-            className={inputStyle(theme, hasError)}
-            value={value}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            {...rest}
-          />
+    const handleChange = useCallback(
+      (event: ChangeEvent<HTMLInputElement>) => {
+        if (onChange) onChange(event);
+        setInput(event.target.value);
+      },
+      [onChange],
+    );
+
+    return (
+      <div>
+        <div className={containerStyle(theme, hasError)}>
+          {placeholder && (
+            <span className={placeholderStyle(theme, isFocus, !!input, hasError, onChangeless)}>{placeholder}</span>
+          )}
+          <div className={inputWrapperStyle(onChangeless)}>
+            <input
+              ref={ref}
+              className={inputStyle(theme, hasError)}
+              value={input}
+              onFocus={handleFocus}
+              onBlur={handleBlur}
+              onChange={handleChange}
+              {...rest}
+            />
+          </div>
         </div>
+        {hasError && (
+          <div className={errorWrapperStyle}>
+            <Text theme={theme} size="caption" align="left" text={errorMessage ?? ''} color="red_10" />
+          </div>
+        )}
       </div>
-      {hasError && (
-        <div className={errorWrapperStyle}>
-          <Text theme={theme} size="caption" align="left" text={errorMessage ?? ''} color="red_10" />
-        </div>
-      )}
-    </div>
-  );
-}
+    );
+  },
+);
 
 const containerStyle = (theme: Theme, isError?: boolean) => css`
   box-sizing: border-box;

--- a/src/components/Input/applyProperties.framer.ts
+++ b/src/components/Input/applyProperties.framer.ts
@@ -5,11 +5,6 @@ import { Input } from './Input';
 
 applyFramerProperties(Input, {
   theme: themeProperty,
-  value: {
-    title: 'Value',
-    type: ControlType.String,
-    defaultValue: 'value',
-  },
   onChangeless: {
     title: 'onChangeless',
     type: ControlType.Boolean,
@@ -25,13 +20,4 @@ applyFramerProperties(Input, {
     type: ControlType.String,
     defaultValue: '에러 메시지',
   },
-  placeholder: {
-    title: 'Placeholder',
-    type: ControlType.String,
-    defaultValue: 'placeholder',
-  },
-  onChange: {
-    title: 'onChange',
-    type: ControlType.EventHandler,
-  }, //TODO: framer 에서 보임?
 });

--- a/src/components/Input/applyProperties.framer.ts
+++ b/src/components/Input/applyProperties.framer.ts
@@ -20,4 +20,9 @@ applyFramerProperties(Input, {
     type: ControlType.String,
     defaultValue: '에러 메시지',
   },
+  placeholder: {
+    title: 'placeholder',
+    type: ControlType.String,
+    defaultValue: 'placeholder',
+  },
 });


### PR DESCRIPTION
## 바뀐점
1. Input을 ref로도 컨트롤 할 수 있도록 forwardRef로 감쌌습니다.
2. Input 컴포넌트 내부에도 state를 가지고 있도록 수정했습니다.

## 바꾼이유
1. 한 컴포넌트 안에 input 컴포넌트가 많을 때 각각 input 컴포넌트를 state로 관리하는 것보다 ref로 관리하는 게 편할 때가 있어서 forwardRef로 감쌌습니다.(ex. react-hook-form 사용..?)
2. html input element를 감싼 컴포넌트(Input과 같은)를 만들고 그 컴포넌트를 사용할 때, 감싼 컴포넌트 내부에 state가 없을 시 프레이머에서 제대로 동작하지 않는 오류가 있어서 내부에도 state를 추가했습니다.(스토리북에서도 똑같은 오류가 있었는데 실제로 사용할 땐 내부에 state가 없어도 괜찮더라구요..?)

## 설명
- placeholder역할을 하는 span의 애니메이션 제어를 위해 input.length를 사용했었는데 html input의 type이 `string | number | readonly string[] | undefined`라 `!!input`으로 수정해서 입력값이 있는지 없는지 판단하도록 수정했습니다.
- Props interface에서 value를 명시하진 않았습니다(어차피 InputHtmlAttribute<HTMLInputElement>안에 있으니까..?). 
그 외 input의 attribute들도 역시 다 가지고 있어서 addPropertyControls.ts에서 value나 placeholder를 따로 명시해주는 게 맞는지 잘 모르겠어서 추가한 onChangeless, hasError, errorMessage 외에는 다 지웠는데 의견 부탁드립니다..
