### PR TITLE
Style: tailwind classname sort 적용

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,7 @@
   "printWidth": 120,
   "endOfLine": "auto",
   "tabWidth": 2,
-  "semi": true
+  "semi": true,
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "tailwindFunctions": ["classnames"]
 }

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "ci:test": "echo no test",
     "ci:lint": "eslint 'src/**/*.{ts,tsx}' --config .eslintrc.js",
     "ci:format": "prettier --check src/**/*.{ts,tsx}",
-    "ci:format:fix": "prettier --cache --write ./src",
     "ci:typecheck": "tsc --noEmit",
+    "format:fix": "prettier --cache --write ./src",
     "version": "echo $npm_package_version",
     "template": "plop"
   },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ci:test": "echo no test",
     "ci:lint": "eslint 'src/**/*.{ts,tsx}' --config .eslintrc.js",
     "ci:format": "prettier --check src/**/*.{ts,tsx}",
+    "ci:format:fix": "prettier --cache --write ./src",
     "ci:typecheck": "tsc --noEmit",
     "version": "echo $npm_package_version",
     "template": "plop"
@@ -88,6 +89,7 @@
     "postcss-discard-comments": "^6.0.0",
     "postcss-modules": "^4.1.3",
     "prettier": "^2.7.1",
+    "prettier-plugin-tailwindcss": "^0.3.0",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -11,7 +11,7 @@ export function Avatar({ src, alt = '', size = '40px' }: Props) {
     <img
       src={src}
       alt={alt}
-      className={cx('rounded-full object-cover', { 'w-10 h-10': size === '40px', 'w-16 h-16': size === '64px' })}
+      className={cx('rounded-full object-cover', { 'h-10 w-10': size === '40px', 'h-16 w-16': size === '64px' })}
     />
   );
 }

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -25,7 +25,7 @@ export function Badge({ color = 'outline', text, className }: Props) {
   return (
     <div
       className={twMerge(
-        cx('px-2 py-[3px] w-fit rounded-lg', colorConfig[color], {
+        cx('w-fit rounded-lg px-2 py-[3px]', colorConfig[color], {
           'border border-border-secondary dark:border-border-secondary_dark': color === 'outline',
         }),
         className,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -26,7 +26,7 @@ export function Button({ variant = 'primary', text, icon, className, ...restProp
   return (
     <button
       className={twMerge(
-        `group h-8 flex flex-row items-center gap-2 rounded-2xl border border-solid transition-all duration-300 active:scale-95 ${variantStyles[variant]}`,
+        `group flex h-8 flex-row items-center gap-2 rounded-2xl border border-solid transition-all duration-300 active:scale-95 ${variantStyles[variant]}`,
         icon && !text ? 'px-2' : 'px-3',
         className,
       )}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -11,11 +11,11 @@ type Props = {
 
 export function Card({ imageSrc, imageAlt, primary = '', secondary = '', detail }: Props) {
   return (
-    <div className="w-[278px] flex flex-col group">
-      <div className="group-hover:mt-[-8px] transition-spacing ease-in-out duration-300">
+    <div className="group flex w-[278px] flex-col">
+      <div className="transition-spacing duration-300 ease-in-out group-hover:mt-[-8px]">
         <Thumbnail src={imageSrc} alt={imageAlt} width={278} ratio="16:9" />
       </div>
-      <div className="mt-3 group-hover:mt-5 transition-spacing ease-in-out duration-300">
+      <div className="mt-3 transition-spacing duration-300 ease-in-out group-hover:mt-5">
         <Text text={`${primary} · ${secondary}`} size="body2" weight="regular" color="secondary" />
       </div>
       {detail && <Text text={detail} size="body1" weight="medium" color="primary" className="line-clamp-1" />}

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -12,7 +12,7 @@ export function Chip({ icon, text, isSelected }: Props) {
   return (
     <div
       className={cx(
-        'w-fit h-8 flex flex-row items-center rounded-lg select-none group',
+        'group flex h-8 w-fit select-none flex-row items-center rounded-lg',
         text ? 'px-3' : 'px-2',
         isSelected
           ? 'bg-bg-secondary dark:bg-bg-secondary_dark'

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -34,7 +34,7 @@ export function Comment({
   onClickReply,
 }: Props) {
   return (
-    <div className="flex flex-col gap-3 w-[720px] overflow-hidden break-words">
+    <div className="flex w-[720px] flex-col gap-3 overflow-hidden break-words">
       <div className="flex flex-row items-start gap-2">
         <AvatarText src={avatarSrc} alt={avatarAlt} mainText={username} subText={time} />
         {isAuthor && <Badge color="outline" text="작성자" className="ml-1" />}
@@ -48,7 +48,7 @@ export function Comment({
           className={cx('px-0', { '[&>p]:text-color-system_200 [&>p]:dark:text-color-system_200': isLiked })}
           onClick={onClickLike}
         />
-        <Button text="답글달기" variant="text" className="px-0 mx-4" onClick={onClickReply} />
+        <Button text="답글달기" variant="text" className="mx-4 px-0" onClick={onClickReply} />
         <Button text="수정하기" variant="text" className="px-0" onClick={onClickEdit} />
       </div>
     </div>

--- a/src/components/CommentInput/CommentInput.tsx
+++ b/src/components/CommentInput/CommentInput.tsx
@@ -12,10 +12,10 @@ interface CommentInputProps extends InputHTMLAttributes<HTMLInputElement> {}
  */
 export const CommentInput = forwardRef<HTMLInputElement, CommentInputProps>(({ className, ...restProps }, ref) => {
   return (
-    <div className="flex items-center rounded-3xl p-2 pl-4 border-border-secondary border focus-within:border-color-system_200">
+    <div className="flex items-center rounded-3xl border border-border-secondary p-2 pl-4 focus-within:border-color-system_200">
       <input
         ref={ref}
-        className={cx('flex-1 w-full h-8 text-sm bg-transparent outline-none', className)}
+        className={cx('h-8 w-full flex-1 bg-transparent text-sm outline-none', className)}
         {...restProps}
       />
       <Button type="submit" icon={SendIcon} aria-label="댓글 작성" />

--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -9,7 +9,7 @@ export function Divider({ variant = 'primary', className, ...restProps }: Divide
   return (
     <div
       className={cx(
-        'w-full h-[1px]',
+        'h-[1px] w-full',
         {
           'bg-border-primary dark:bg-border-primary_dark': variant === 'primary',
           'bg-border-secondary dark:bg-border-secondary_dark': variant === 'secondary',

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -13,15 +13,15 @@ interface Props {
 export function Footer({ githubLink = '', mailLink = '', text }: Props) {
   return (
     <div className="flex flex-col">
-      <div className="mb-6 w-full flex flex-row align-center justify-center gap-2">
-        <a href={githubLink} target="_blank" className="w-fit h-fit inline-block">
+      <div className="align-center mb-6 flex w-full flex-row justify-center gap-2">
+        <a href={githubLink} target="_blank" className="inline-block h-fit w-fit">
           <Button variant="secondary" icon={Github} />
         </a>
-        <a href={mailLink} target="_blank" className="w-fit h-fit inline-block">
+        <a href={mailLink} target="_blank" className="inline-block h-fit w-fit">
           <Button variant="secondary" icon={Mail} />
         </a>
       </div>
-      <div className="flex align-center justify-center">
+      <div className="align-center flex justify-center">
         <Text size="body2" color="secondary" text={text} />
       </div>
     </div>

--- a/src/components/GroupHeader/GroupHeader.tsx
+++ b/src/components/GroupHeader/GroupHeader.tsx
@@ -10,11 +10,11 @@ interface Props {
 export function GroupHeader({ href, text }: Props) {
   return (
     <a
-      className="flex flex-row items-center gap-1 hover:gap-2 transition-gap duration-300 ease-in-out text-text-primary dark:text-text-primary_dark"
+      className="flex flex-row items-center gap-1 text-text-primary transition-gap duration-300 ease-in-out hover:gap-2 dark:text-text-primary_dark"
       href={href}
     >
       <Text text={text} size="heading3" weight="semibold" />
-      <Icon svg={ChevronRight} className="w-6 h-6" />
+      <Icon svg={ChevronRight} className="h-6 w-6" />
     </a>
   );
 }

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -49,7 +49,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
           {label && (
             <label
               htmlFor={idFromProps ?? id}
-              className='before:content-["*"] before:mr-1 text-sm leading-[1.8] font-normal text-text-secondary dark:text-text-secondary_dark'
+              className='text-sm font-normal leading-[1.8] text-text-secondary before:mr-1 before:content-["*"] dark:text-text-secondary_dark'
             >
               {label}
             </label>
@@ -65,7 +65,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
           )}
         </div>
         <div
-          className={cx('flex items-center w-full rounded-lg px-4', {
+          className={cx('flex w-full items-center rounded-lg px-4', {
             'border border-solid border-border-primary bg-bg-primary_alpha_0 focus-within:border-color-blue_200':
               variant === 'outline',
             'bg-bg-secondary dark:bg-bg-secondary_dark': variant === 'filled',
@@ -75,7 +75,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(
           <input
             ref={ref}
             id={idFromProps ?? id}
-            className="w-full h-[44px] bg-transparent focus:outline-none text-base font-normal leading-[1.5] text-text-primary dark:text-text-primary_dark placeholder:text-text-tertiary dark:placeholder:text-text-tertiary_dark"
+            className="h-[44px] w-full bg-transparent text-base font-normal leading-[1.5] text-text-primary placeholder:text-text-tertiary focus:outline-none dark:text-text-primary_dark dark:placeholder:text-text-tertiary_dark"
             value={value}
             onChange={handleChange}
             maxLength={maxLength}

--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -34,10 +34,10 @@ export function ListItem({
 }: Props) {
   return (
     <div
-      className="w-full cursor-pointer active:scale-95 transition-transform duration-300 ease-out select-none"
+      className="w-full cursor-pointer select-none transition-transform duration-300 ease-out active:scale-95"
       onClick={onClick}
     >
-      <div className="flex flex-row justify-between items-center py-4">
+      <div className="flex flex-row items-center justify-between py-4">
         <div className="flex flex-row items-center">
           {thumbnailSrc && <Thumbnail src={thumbnailSrc} alt={title} width={85} rounded="8px" ratio="16:9" />}
           <div className="ml-3 flex-1">

--- a/src/components/Sample/Sample.tsx
+++ b/src/components/Sample/Sample.tsx
@@ -12,7 +12,7 @@ export function Sample({ text }: Props) {
     <div className="flex flex-row items-center">
       <Text text={`This is Samp3le! "${text}"`} size="heading3" weight="semibold" className="mr-2" />
       <Icon svg={Github} size="xsmall" />
-      <Icon svg={Face} size="medium" className="inline-block dark:fill-white fill-yellow-400 ml-1" />
+      <Icon svg={Face} size="medium" className="ml-1 inline-block fill-yellow-400 dark:fill-white" />
     </div>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8640,6 +8640,11 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
+prettier-plugin-tailwindcss@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.3.0.tgz#8299b307c7f6467f52732265579ed9375be6c818"
+  integrity sha512-009/Xqdy7UmkcTBpwlq7jsViDqXAYSOMLDrHAdTMlVZOrKfM2o9Ci7EMWTMZ7SkKBFTG04UM9F9iM2+4i6boDA==
+
 prettier@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"


### PR DESCRIPTION
## 바뀐점

tailwind classname이 정렬되게 설정하였습니다. 편-안 😃 

## 바꾼이유

코드 내 tailwind classname 순서의 일관성을 위하여

## 설명

- prettier-plugin-tailwindcss 플러그인을 설정
- 전체 formatting 적용한번 했습니다.
