### PR TITLE
Feature: Text Button인 경우 activated props 추가

### DIFF
--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -6,6 +6,14 @@ type Component = typeof Button;
 const meta: Meta<Component> = {
   title: 'rookies/Button',
   component: Button,
+  argTypes: {
+    activated: {
+      if: {
+        arg: 'variant',
+        eq: 'text',
+      },
+    },
+  },
 };
 
 type Story = StoryObj<Component>;
@@ -28,6 +36,14 @@ export const Text: Story = {
   args: {
     ...Primary.args,
     variant: 'text',
+  },
+};
+
+export const TextActivated: Story = {
+  args: {
+    ...Primary.args,
+    variant: 'text',
+    activated: true,
   },
 };
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -5,24 +5,38 @@ import cx from 'classnames';
 import { Icon } from '../Icon';
 import { Text } from '../Text';
 
-type ButtonVariant = 'primary' | 'secondary' | 'text';
+type ButtonVariant =
+  | {
+      variant: 'text';
+      activated?: boolean;
+    }
+  | {
+      variant: 'primary';
+    }
+  | {
+      variant: 'secondary';
+    };
 
-interface ButtonProps {
-  variant?: ButtonVariant;
+type ButtonProps = Partial<ButtonVariant> & {
   text?: string;
   icon?: FC<SVGAttributes<SVGSVGElement>>;
-}
+};
 
 type Props = ButtonProps & Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof ButtonProps>;
 
-const variantStyles: Record<ButtonVariant, string> = {
+const variantStyles: Record<ButtonVariant['variant'], string> = {
   primary: 'bg-color-system_200 border-0 hover:bg-color-system_300',
   secondary:
     'border-border-primary dark:border-border-primary_dark hover:border-color-system_200 hover:dark:border-color-system_200',
   text: 'border-0',
 };
 
-export function Button({ variant = 'primary', text, icon, className, ...restProps }: Props) {
+export function Button(props: Props) {
+  const { text, icon, className, ...restProps } = props;
+
+  const variant = props.variant ?? 'primary';
+  const activated = props.variant === 'text' && props.activated;
+
   return (
     <button
       className={twMerge(
@@ -41,6 +55,7 @@ export function Button({ variant = 'primary', text, icon, className, ...restProp
             'transition-colors duration-300',
             {
               'group-hover:fill-color-system_200': variant !== 'primary',
+              'fill-color-system_200': activated,
             },
           )}
         />
@@ -53,6 +68,7 @@ export function Button({ variant = 'primary', text, icon, className, ...restProp
           color={variant === 'primary' ? 'white' : 'secondary'}
           className={cx('transition-colors duration-300', {
             'group-hover:text-color-system_200': variant !== 'primary',
+            'text-color-system_200': activated,
           })}
         />
       )}

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -1,3 +1,5 @@
+import { twMerge } from 'tailwind-merge';
+
 export type TextSize = 'heading1' | 'heading2' | 'heading3' | 'body1' | 'body2' | 'small';
 type TextWeight = 'regular' | 'medium' | 'semibold';
 type TextAlign = 'left' | 'right' | 'center';
@@ -104,13 +106,14 @@ export function Text({
 }: Props) {
   return (
     <p
-      className={`font-display
-        ${textSizeConfig[size]}
-        ${textWeightConfig[weight]}
-        ${textAlignConfig[align]}
-        ${textColorConfig[color]}
-        ${className}
-        `}
+      className={twMerge(
+        'font-display',
+        textSizeConfig[size],
+        textWeightConfig[weight],
+        textAlignConfig[align],
+        textColorConfig[color],
+        className,
+      )}
     >
       {text}
     </p>


### PR DESCRIPTION
## 바뀐점

Text Button 일 경우에 activated props를 전달 가능하게 변경

## 바꾼이유

Feed에서 좋아요 버튼의 경우 활성화 상태가 필요하기 때문에

## 설명

- 선택적으로 variant가 text일 경우에만 activated props를 추가하기 위해서 discriminated union type을 사용함(영훈님이 갈쳐주심)
- https://m.blog.naver.com/mym0404/221800393600
- story에서 `if` property로 선택적으로 table property 표시
