### PR TITLE
fix: input size variant, framer outline

### DIFF
--- a/src/components/Input/Input.framer.tsx
+++ b/src/components/Input/Input.framer.tsx
@@ -41,7 +41,7 @@ applyFramerProperties(Input, {
   variant: {
     title: 'Variant',
     type: ControlType.Enum,
-    options: ['outlined', 'filled'],
+    options: ['outline', 'filled'],
     defaultValue: 'outlined',
   },
   focused: {

--- a/src/components/Input/Input.framer.tsx
+++ b/src/components/Input/Input.framer.tsx
@@ -4,7 +4,7 @@ import { applyFramerProperties, FramerProvider } from '../../common/framer';
 import { Input as _Input } from './Input';
 
 interface InputProps {
-  variant: 'outline' | 'filled';
+  variant: 'outlined' | 'filled';
   value: string;
   label: string;
   hasError: boolean;
@@ -41,7 +41,7 @@ applyFramerProperties(Input, {
   variant: {
     title: 'Variant',
     type: ControlType.Enum,
-    options: ['outline', 'filled'],
+    options: ['outlined', 'filled'],
     defaultValue: 'outlined',
   },
   focused: {

--- a/src/components/Input/Input.framer.tsx
+++ b/src/components/Input/Input.framer.tsx
@@ -5,6 +5,7 @@ import { Input as _Input } from './Input';
 
 interface InputProps {
   variant: 'outlined' | 'filled';
+  size: 'small' | 'medium';
   value: string;
   label: string;
   hasError: boolean;
@@ -38,6 +39,12 @@ export function Input(props: InputProps) {
 }
 
 applyFramerProperties(Input, {
+  size: {
+    title: 'Size',
+    type: ControlType.Enum,
+    options: ['small', 'medium'],
+    defaultValue: 'medium',
+  },
   variant: {
     title: 'Variant',
     type: ControlType.Enum,

--- a/src/components/Input/Input.stories.ts
+++ b/src/components/Input/Input.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta<Component> = {
 
 type Story = StoryObj<Component>;
 export const Primary: Story = {
-  args: { label: '필수 항목', placeholder: '', maxLength: 10, variant: 'outline', hasError: false },
+  args: { label: '필수 항목', placeholder: '', maxLength: 10, variant: 'outlined', hasError: false },
 };
 
 export const DefaultValue: Story = {

--- a/src/components/Input/Input.stories.ts
+++ b/src/components/Input/Input.stories.ts
@@ -9,7 +9,7 @@ const meta: Meta<Component> = {
 
 type Story = StoryObj<Component>;
 export const Primary: Story = {
-  args: { label: '필수 항목', placeholder: '', maxLength: 10, variant: 'outlined', hasError: false },
+  args: { label: '필수 항목', placeholder: '', maxLength: 10, variant: 'outlined', hasError: false, required: true },
 };
 
 export const DefaultValue: Story = {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -7,46 +7,38 @@ import { useControllableState } from './useControllableState';
 interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
   size?: 'small' | 'medium';
   /**
-   * 라벨
-   * @description Input 상단에 표시되는 라벨
+   * Input 상단에 표시되는 라벨
    */
   label?: string;
   /**
-   * 값
-   * @description Input의 값, undefined일 경우 컴포넌트 내부에서 관리
+   * Input의 값, undefined일 경우 컴포넌트 내부에서 관리
    **/
   value?: string;
   /**
-   * 기본값
-   * @description Input의 기본값, uncontrolled 방식으로 사용할 때의 기본값
+   * uncontrolled 방식으로 사용할 때 Input의 기본값
    */
   defaultValue?: string;
   /**
-   * 서브 라벨
-   * @description Input 하단에 표시되는 서브 라벨
+   * Input 하단에 표시되는 서브 라벨
    */
   subLabel?: string;
   /**
-   * Input 스타일
-   * @description Input의 스타일, outline일 경우 테두리가 있고 filled일 경우 테두리가 없음
+   * Input의 스타일, outline일 경우 테두리가 있고 filled일 경우 테두리가 없음
    * @default outline
    **/
   variant?: 'outlined' | 'filled';
   /**
-   * 필수 여부
-   * @description Input이 필수인지 여부, true일 경우 라벨 앞에 * 표시
+   * Input이 필수인지 여부, true일 경우 라벨 앞에 * 표시
    * @default false
    */
   required?: boolean;
   /**
-   * 에러 여부
-   * @description Input에 에러가 있는지 여부, true일 경우 테두리가 빨간색으로 표시
+   * Input에 에러가 있는지 여부, true일 경우 테두리가 빨간색으로 표시
    * @default false
    */
   hasError?: boolean;
   /**
-   * 오른쪽 추가 요소
-   * @description Input 오른쪽에 추가되는 요소
+   * Input 오른쪽에 추가되는 요소
    * @example
    * ```tsx
    * <Input
@@ -56,8 +48,7 @@ interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>
    */
   rightAddon?: ReactNode;
   /**
-   * 값 변경 이벤트
-   * @description Input 값이 변경될 때 호출되는 이벤트
+   * Input 값이 변경될 때 호출되는 이벤트
    * @param value 변경된 값
    * @example
    * ```tsx

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -4,8 +4,9 @@ import { forwardRef, useId } from 'react';
 import { Text } from '../Text';
 import { useControllableState } from './useControllableState';
 
-interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
   label?: string;
+  size?: 'small' | 'medium';
   value?: string;
   defaultValue?: string;
   subLabel?: string;
@@ -20,6 +21,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
   (
     {
       id: idFromProps,
+      size = 'medium',
       label,
       value: valueFromProps,
       defaultValue,
@@ -82,7 +84,13 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           <input
             ref={ref}
             id={idFromProps ?? id}
-            className="h-[44px] w-full bg-transparent text-base font-normal leading-[1.5] text-text-primary placeholder:text-text-tertiary focus:outline-none dark:text-text-primary_dark dark:placeholder:text-text-tertiary_dark"
+            className={cx(
+              'w-full bg-transparent text-base font-normal leading-[1.5] text-text-primary placeholder:text-text-tertiary focus:outline-none dark:text-text-primary_dark dark:placeholder:text-text-tertiary_dark',
+              {
+                'h-[44px]': size === 'medium',
+                'h-[32px]': size === 'small',
+              },
+            )}
             value={value}
             onChange={handleChange}
             maxLength={maxLength}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -9,7 +9,7 @@ interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   value?: string;
   defaultValue?: string;
   subLabel?: string;
-  variant?: 'outline' | 'filled';
+  variant?: 'outlined' | 'filled';
   required?: boolean;
   hasError?: boolean;
   rightAddon?: ReactNode;
@@ -74,7 +74,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         <div
           className={cx('flex w-full items-center rounded-lg px-4', {
             'border border-solid border-border-primary bg-bg-primary_alpha_0 focus-within:border-color-blue_200':
-              variant === 'outline',
+              variant === 'outlined',
             'bg-bg-secondary dark:bg-bg-secondary_dark': variant === 'filled',
             'border-color-red focus-within:border-color-red': hasError,
           })}

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -5,6 +5,10 @@ import { Text } from '../Text';
 import { useControllableState } from './useControllableState';
 
 interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  /**
+   * Input의 크기
+   * @default medium
+   */
   size?: 'small' | 'medium';
   /**
    * Input 상단에 표시되는 라벨

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -5,18 +5,80 @@ import { Text } from '../Text';
 import { useControllableState } from './useControllableState';
 
 interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
-  label?: string;
   size?: 'small' | 'medium';
+  /**
+   * 라벨
+   * @description Input 상단에 표시되는 라벨
+   */
+  label?: string;
+  /**
+   * 값
+   * @description Input의 값, undefined일 경우 컴포넌트 내부에서 관리
+   **/
   value?: string;
+  /**
+   * 기본값
+   * @description Input의 기본값, uncontrolled 방식으로 사용할 때의 기본값
+   */
   defaultValue?: string;
+  /**
+   * 서브 라벨
+   * @description Input 하단에 표시되는 서브 라벨
+   */
   subLabel?: string;
+  /**
+   * Input 스타일
+   * @description Input의 스타일, outline일 경우 테두리가 있고 filled일 경우 테두리가 없음
+   * @default outline
+   **/
   variant?: 'outlined' | 'filled';
+  /**
+   * 필수 여부
+   * @description Input이 필수인지 여부, true일 경우 라벨 앞에 * 표시
+   * @default false
+   */
   required?: boolean;
+  /**
+   * 에러 여부
+   * @description Input에 에러가 있는지 여부, true일 경우 테두리가 빨간색으로 표시
+   * @default false
+   */
   hasError?: boolean;
+  /**
+   * 오른쪽 추가 요소
+   * @description Input 오른쪽에 추가되는 요소
+   * @example
+   * ```tsx
+   * <Input
+   *  rightAddon={<Button>전송</Button>}
+   * />
+   * ```
+   */
   rightAddon?: ReactNode;
+  /**
+   * 값 변경 이벤트
+   * @description Input 값이 변경될 때 호출되는 이벤트
+   * @param value 변경된 값
+   * @example
+   * ```tsx
+   * <Input
+   *  onValueChange={(value) => console.log(value)}
+   * />
+   * ```
+   **/
   onValueChange?: (value: string) => void;
 }
 
+/**
+ * `Input` 컴포넌트는 사용자의 입력을 받는 컴포넌트입니다.
+ * @example
+ * ```tsx
+ * <Input
+ *  label="이메일"
+ *  placeholder="이메일을 입력해주세요."
+ * />
+ * ```
+ */
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   (
     {


### PR DESCRIPTION
## 바뀐점

- input size variant를 추가합니다.
- input framer 단에서 outline이 누락되던 문제를 수정합니다.

## 바꾼이유

- 베손의 제보,,

## 설명

수작업으로 진행하여 typesafe하지 않았던 것 같아 주말간 framer, storybook 관련하여 조금 수정해볼게요
+ input addon 및 인터페이스도 조금 수정해볼게요
