### PR TITLE
feat: context, event utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ release
 src/styles/_*.css
 .pages
 style.css
+.idea

--- a/src/utils/composeEvent.ts
+++ b/src/utils/composeEvent.ts
@@ -1,0 +1,13 @@
+export function composeEventHandlers<E>(
+  originalEventHandler?: (event: E) => void,
+  ourEventHandler?: (event: E) => void,
+  { checkForDefaultPrevented = true } = {},
+) {
+  return function handleEvent(event: E) {
+    originalEventHandler?.(event);
+
+    if (checkForDefaultPrevented === false || !(event as unknown as Event).defaultPrevented) {
+      return ourEventHandler?.(event);
+    }
+  };
+}

--- a/src/utils/createContext.tsx
+++ b/src/utils/createContext.tsx
@@ -1,0 +1,40 @@
+import { useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { createContext as createContext_, useContext as useContext_ } from 'react';
+
+export function createContext<ContextValueType extends object | null>(
+  rootComponentName: string,
+  defaultContext?: ContextValueType,
+) {
+  const Context = createContext_<ContextValueType | undefined>(defaultContext);
+
+  function Provider(
+    props: ContextValueType & {
+      children?: ReactNode;
+    },
+  ) {
+    const { children, ...contexts } = props;
+
+    const value = useMemo(() => contexts, Object.values(contexts)) as ContextValueType;
+
+    return <Context.Provider value={value}>{children}</Context.Provider>;
+  }
+
+  function useContext(consumerName: string) {
+    const context = useContext_(Context);
+
+    if (context) {
+      return context;
+    }
+
+    if (defaultContext !== undefined) {
+      return defaultContext;
+    }
+
+    throw new Error(`${consumerName} 컴포넌트는 ${rootComponentName}.Provider 하위에서 사용되어야 합니다.`);
+  }
+
+  Provider.displayName = `${rootComponentName}.Provider`;
+
+  return [Provider, useContext] as const;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,5 @@ export * from './isDarkTheme';
 export * from './isOsDarkTheme';
 export * from './setTheme';
 export * from './toggleTheme';
+export * from './composeEvent';
+export * from './createContext';


### PR DESCRIPTION
## 바뀐점

- 컴포넌트간 context 관리에 도움이 되는 유틸 함수를 생성했어요.
- event 를 선언적으로 compose할 수 있는 유틸 함수를 생성했어요.

## 바꾼이유

## 설명

_radix 에서 슬쩍했습니다_

createContext 사용법은 아래와 같아요.

```tsx
// context.ts
export const [InputProvider, useInputContext] = createContext<{value: string;}>('Input', {
  value: '',
});

// input or input's compound component.ts
const { value } = useInputContext('Input.???);
```
provider 생성 및 useContext 처리를 함수 내부에서 하기에 사용성이 좋아요~! (경험이 좋았어요)

```tsx
<input
        onChange={composeEventHandlers(onChange, (event) => {
          ~~~~
          
        })}
      />
```
event를 다수의 핸들러에게 넘길 때 편하게 사용할 수 있어요.

