### PR TITLE
design: listitem thumbnail 없을 시 left margin 제거

### DIFF
--- a/src/components/ListItem/ListItem.tsx
+++ b/src/components/ListItem/ListItem.tsx
@@ -39,8 +39,10 @@ export function ListItem({
     >
       <div className="flex flex-row items-center justify-between py-4">
         <div className="flex flex-row items-center">
-          {thumbnailSrc && <Thumbnail src={thumbnailSrc} alt={title} width={85} rounded="8px" ratio="16:9" />}
-          <div className="ml-3 flex-1">
+          {thumbnailSrc && (
+            <Thumbnail src={thumbnailSrc} alt={title} width={85} rounded="8px" ratio="16:9" className="mr-3" />
+          )}
+          <div className="flex-1">
             {MergedSecondaryText(secondaryTextFirst, secondaryTextSecond)}
             <Text text={title} size="body1" weight="medium" color="primary" />
           </div>


### PR DESCRIPTION
## 바뀐점

 listitem thumbnail 없을 시 left margin 제거

## 바꾼이유

배손님의 피드백으로

## 설명

썸네일에 classname으로 margin-right를 주는 방식으로 수정했습니다.
