### PR TITLE
fix: input empty div, framer preview bug

### DIFF
--- a/src/components/Input/Input.framer.tsx
+++ b/src/components/Input/Input.framer.tsx
@@ -1,5 +1,5 @@
 import { ControlType } from 'framer';
-import { ComponentProps, useRef } from 'react';
+import { ComponentProps, useEffect, useState } from 'react';
 import { applyFramerProperties, FramerProvider } from '../../common/framer';
 import { Input as _Input } from './Input';
 
@@ -26,14 +26,18 @@ const transformProps = (props: InputProps): ComponentProps<typeof _Input> => {
 };
 
 export function Input(props: InputProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
+  const [value, setValue] = useState(props.value);
+
+  useEffect(() => {
+    setValue(props.value);
+  }, [props.value]);
 
   const { children, ...transformedProps } = transformProps(props);
   void children;
 
   return (
     <FramerProvider>
-      <_Input ref={inputRef} {...transformedProps} />
+      <_Input {...transformedProps} value={value} onValueChange={setValue} />
     </FramerProvider>
   );
 }

--- a/src/components/Input/Input.stories.ts
+++ b/src/components/Input/Input.stories.ts
@@ -9,10 +9,17 @@ const meta: Meta<Component> = {
 
 type Story = StoryObj<Component>;
 export const Primary: Story = {
+  argTypes: {
+    maxLength: {
+      description: '최대 글자 수',
+      control: {
+        type: 'number',
+      },
+    },
+  },
   args: {
     label: '필수 항목',
     placeholder: '',
-    maxLength: 10,
     variant: 'outlined',
     hasError: false,
     required: true,

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -121,7 +121,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           className,
         )}
       >
-        {showTopAddon && (
+        {showTopAddon ? (
           <div className="mb-2 flex w-full">
             {label && (
               <label
@@ -146,7 +146,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
               />
             ) : null}
           </div>
-        )}
+        ) : null}
         <div
           className={cx('flex w-full items-center rounded-lg border border-solid px-4', {
             'border-border-primary bg-transparent focus-within:border-color-blue_200 dark:border-border-primary_dark':

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -109,40 +109,44 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       setValue(e.target.value);
     };
 
+    const showTopAddon = label || maxLength;
+
     return (
       <div
         className={cx(
-          'flex flex-col space-y-2',
+          'flex flex-col',
           {
             'opacity-40': disabled,
           },
           className,
         )}
       >
-        <div className="flex w-full">
-          {label && (
-            <label
-              htmlFor={idFromProps ?? id}
-              className={cx(
-                'text-sm font-normal leading-[1.8] text-text-secondary before:mr-1 dark:text-text-secondary_dark',
-                {
-                  'before:content-["*"]': required,
-                },
-              )}
-            >
-              {label}
-            </label>
-          )}
-          {maxLength ? (
-            <Text
-              className="ml-auto"
-              text={`(${value.length}/${maxLength})`}
-              size="body2"
-              weight="regular"
-              color="secondary"
-            />
-          ) : null}
-        </div>
+        {showTopAddon && (
+          <div className="mb-2 flex w-full">
+            {label && (
+              <label
+                htmlFor={idFromProps ?? id}
+                className={cx(
+                  'text-sm font-normal leading-[1.8] text-text-secondary before:mr-1 dark:text-text-secondary_dark',
+                  {
+                    'before:content-["*"]': required,
+                  },
+                )}
+              >
+                {label}
+              </label>
+            )}
+            {maxLength ? (
+              <Text
+                className="ml-auto"
+                text={`(${value.length}/${maxLength})`}
+                size="body2"
+                weight="regular"
+                color="secondary"
+              />
+            ) : null}
+          </div>
+        )}
         <div
           className={cx('flex w-full items-center rounded-lg border border-solid px-4', {
             'border-border-primary bg-transparent focus-within:border-color-blue_200 dark:border-border-primary_dark':
@@ -171,7 +175,11 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           />
           {rightAddon && <span className="flex">{rightAddon}</span>}
         </div>
-        {subLabel && <Text text={subLabel} size="body2" weight="regular" color={hasError ? 'red_200' : 'secondary'} />}
+        {subLabel && (
+          <div className="mt-2">
+            <Text text={subLabel} size="body2" weight="regular" color={hasError ? 'red_200' : 'secondary'} />
+          </div>
+        )}
       </div>
     );
   },


### PR DESCRIPTION
## 바뀐점

- topAddon이 없을 때 해당 영역 div를 렌더링하지 않도록 수정합니다.
- framer preview 모드에서 input value가 변경되지 않던 문제를 수정합니다.

## 바꾼이유

- QA?,,

## 설명

framer control panel에서 value:"" 형식으로 기본값을 제공하는데, 해당 기본값으로 인해 input이 controlled 로 동작한 것 같아요.
framer layer에서 상태 하나 집어넣어서 값이 변경되도록 수정합니당

Close #123 #124
