### PR TITLE
feat: cn 유틸함수 추가

### DIFF
--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,4 +1,5 @@
-import cx, { type ArgumentArray } from 'classnames';
+import cx from 'classnames';
+import type { ArgumentArray } from 'classnames';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...args: ArgumentArray) {

--- a/src/utils/cn.ts
+++ b/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import cx, { type ArgumentArray } from 'classnames';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...args: ArgumentArray) {
+  return twMerge(cx(args));
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,3 +4,4 @@ export * from './setTheme';
 export * from './toggleTheme';
 export * from './composeEvent';
 export * from './createContext';
+export * from './cn';


### PR DESCRIPTION
## 바뀐점

classnames를 tailwind-merge의 `twMerge`로 wrapping한 `cn` 유틸함수를 추가했습니다.

## 바꾼이유

- 기존에 코드에선 classnames와 twMerge를 혼용해서 사용하고 있어 일관성이 없습니다.
- classnames의 인자로 전달된 class들은 서로간에 충돌이 일어날 수 있어 twMerge로 안전하게 class를 결합해주는것이 좋습니다.
- https://xionwcfm.tistory.com/328 링크를 참고했슴다
- [cva](https://cva.style/docs/getting-started/typescript)라는것도 있던데 유용해보이긴 합니당

## 설명

> 나중에 classnames,twMerge 쓴곳을 cn으로 전부다 바꾸면 될거같아요

```typescript
// twMerge로 classnames를 한번더 감싸줍니닷
export function cn(...args: ArgumentArray) {
  return twMerge(cx(args));
}
```
